### PR TITLE
fixed unicode issue with _escape() in yamdwe_users.py

### DIFF
--- a/yamdwe_users.py
+++ b/yamdwe_users.py
@@ -94,7 +94,10 @@ def get_mediawiki_users(host, user, password, dbname, tableprefix):
     users = {}
 
     def _escape(field):
-        return unicode(field, "utf-8").replace(":", r"\:")
+        if isinstance(field,unicode):
+            return field.replace(":", r"\:")
+        else:
+            return unicode(field, "utf-8").replace(":", r"\:")
 
     for row in c.fetchall():
         login = names.clean_user(unicode(row[0], "utf-8"))


### PR DESCRIPTION
After successfully moved content from MediaWiki to DokuWiki, I run into this issue, when I executed yamdwe_users.py. I got following error message in line 97:

> TypeError: decoding Unicode is not supported

After a little research I found that solution, which worked for me. I assume this error happened, because usernames from MediaWiki contains non ASCII characters.
As I'm not a Python programmer, please check this patch carefully. 

My environment:
Ubuntu 14.04
MediaWiki 1.22.5
DokuWiki 2014-09-29a "Hrun"
Python 2.7.6
MySQL 5.5.40
DB Table Collations utf8_general_ci
user_name and user_real_name are VARCHAR(255) utf8_bin

Armin
