### PR TITLE
added test case for recognition of new format for mediawiki external lin...

### DIFF
--- a/tests/mediawiki_external_url_format/dokuwiki.txt
+++ b/tests/mediawiki_external_url_format/dokuwiki.txt
@@ -1,0 +1,3 @@
+==== Test ====
+
+convert new mediawiki URL format like git://git.code.sf.net/p/sevenzipjbind/code regardless whether the URL can be opened in browser or not

--- a/tests/mediawiki_external_url_format/mediawiki.txt
+++ b/tests/mediawiki_external_url_format/mediawiki.txt
@@ -1,0 +1,2 @@
+== Test ==
+convert new mediawiki URL format like [git://git.code.sf.net/p/sevenzipjbind/code git://git.code.sf.net/p/sevenzipjbind/code] regardless whether the URL can be opened in browser or not


### PR DESCRIPTION
...ks. The test case fails with 3bb19b668072e5305bcf588988f89f92b91e2aa9. Afaik there's no alternative to the proposed transformation.
