### PR TITLE
added testcase for working around newlines in lists

### DIFF
--- a/tests/newline_pre_block/dokuwiki.txt
+++ b/tests/newline_pre_block/dokuwiki.txt
@@ -1,0 +1,7 @@
+====Newline pre blocks====
+
+  * some text<code>
+some code 1
+some code 2
+</code>some other text</li>
+</ul>

--- a/tests/newline_pre_block/mediawiki.txt
+++ b/tests/newline_pre_block/mediawiki.txt
@@ -1,0 +1,9 @@
+== Newline pre blocks ==
+<ul>
+<li>some text
+<pre>
+some code 1
+some code 2
+</pre>
+some other text</li>
+</ul>


### PR DESCRIPTION
Newline characters before `pre` blocks in mediawiki lists cause the indentation in dokuwiki to break (because it handles context sensitive list markup as annoyingly as possible). `yamdwe` can work around this by removing the newline before the start of the `pre`/`code` element in lists and after the end of the closing `pre`/`code` element.

The test fails with e4cf64d05d6e225061c671d17b7a131c41d4c0f8.