### PR TITLE
added testcase for escaping single quotes in tt mediawiki elements wi…

### DIFF
--- a/tests/escape_single_quotes_in_monospaced/dokuwiki.txt
+++ b/tests/escape_single_quotes_in_monospaced/dokuwiki.txt
@@ -1,0 +1,3 @@
+==== Heading ====
+
+A ''monospaced text <nowiki>'</nowiki>with single quotes<nowiki>'</nowiki>'' at the end of the monospaced block

--- a/tests/escape_single_quotes_in_monospaced/mediawiki.txt
+++ b/tests/escape_single_quotes_in_monospaced/mediawiki.txt
@@ -1,0 +1,2 @@
+== Heading ==
+A <tt>monospaced text 'with single quotes'</tt> at the end of the monospaced block


### PR DESCRIPTION
…th a nowiki element in order to avoid closing of monospaced dokuwiki element after '' has encountered in '''.

This doesn't reflect that the escaping is necessary only if the single quote is the last character before the closing tt tag and that only the last single quote has to be escaped.

This can't be done with a space because it will be included in the monospaced text in dokuwiki.

Ok to open a pull request only or should I move the discussion part to a to be created issue?
