### PR TITLE
fixed unknown formatter warnings with <blockquote> and <br> tags

### DIFF
--- a/wikicontent.py
+++ b/wikicontent.py
@@ -128,7 +128,9 @@ def convert(style, context, trailing_newline):
         ":"   : ("", ""),           # other end of a definition???
         "sub" : ("<sub>","</sub>"),
         "sup" : ("<sup>","</sup>"),
-        "big" : ("**", "**"),        # <big> not in dokuwiki so use bold
+        "big" : ("**", "**"),       # <big> not in dokuwiki so use bold
+        "-" : ("<blockquote>", "</blockquote>"), # use dokuwikis Blockquote Plugin for this
+        "u" : ("", "")              # <br> already handled in TagNode @visitor
         }.get(style.caption, None)
     if formatter is None:
         print("WARNING: Ignoring unknown formatter %s" % style.caption)


### PR DESCRIPTION
Conversion of my wiki worked after fixing issue #30, but I got a bunch of warnings "unknown formatter - " and "unknown formatter u".

Formatter "-" was caused by the use of `<blockquote></blockquote>` tags. I passed them to the dokuwiki output, as they work well with the "Blockquote Plugin" extension.

Formatter "u" was caused by the use of `<br>` tags. They are already handled in the TagNode visitor, so I added empty formatter to avoid the warning.