### PR TITLE
added support for <math> tags, including test files

### DIFF
--- a/tests/math_tags/dokuwiki.txt
+++ b/tests/math_tags/dokuwiki.txt
@@ -1,0 +1,9 @@
+The squared distance from a point on ellipse to a given point$(x,y)$ is:
+
+$$
+\begin{array}{rcl}
+s^{2}&=&(x-a\cos t)^{2}+(y-b\sin t)^{2}\\
+&=&x^{2}+y^{2}+a^{2}\cos^{2}t+b^{2}\sin^{2}t-2xa\cos t-2yb\sin t
+\end{array}
+$$
+

--- a/tests/math_tags/mediawiki.txt
+++ b/tests/math_tags/mediawiki.txt
@@ -1,0 +1,9 @@
+The squared distance from a point on ellipse to a given point<math>(x,y)</math> is:
+
+<math>
+\begin{array}{rcl}
+s^{2}&=&(x-a\cos t)^{2}+(y-b\sin t)^{2}\\
+&=&x^{2}+y^{2}+a^{2}\cos^{2}t+b^{2}\sin^{2}t-2xa\cos t-2yb\sin t
+\end{array}
+</math>
+

--- a/wikicontent.py
+++ b/wikicontent.py
@@ -260,6 +260,19 @@ def convert(tag, context, trailing_newline):
 
     return convert_children(tag, context)
 
+@visitor.when(Math)
+def convert(node, context, trailing_newline):
+    """
+    Convert <math></math> tags for rendering of math terms
+    there are a couple of extension to support this in dokuwiki
+    tested successfully with MathJax plugin
+    """
+    if "\n" in node.math:
+        # multiple lines are a formula block
+        return "$$" + node.math + "$$"
+    # anything else is inline term
+    return "$" + node.math + "$"
+
 # catchall for Node, which is the parent class of everything above
 @visitor.when(Node)
 def convert(node, context, trailing_newline):


### PR DESCRIPTION
Converts `<math>term</math>` into `$term$` and
```
<math>
more
complex
term
</math>
```
into
```
$$
more
complex
term
$$
```

There are a couple of extensions for DokuWiki to support this.
Tested with MathJax plugin.

Without an extension the $ tags and the term are shown as plain text.