### PR TITLE
Domain functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ To start an export, you will need the URL of the mediawiki API (usually http://m
 
     yamdwe.py MEDIAWIKI_API_URL DOKUWIKI_ROOT_PATH
 
-If you need to log in to to your Mediawiki install (either with a Mediawiki username, or via HTTP Basic Auth) then run `yamdwe.py -h` to view the command line options for authentication.
+If you need to log in to to your Mediawiki install (either with a Mediawiki username and if you are in a domain with the domain-name, or via HTTP Basic Auth) then run `yamdwe.py -h` to view the command line options for authentication.
 
 If installation goes well it should print the names of pages and images as it is exporting, and finally print "Done". This process can be slow, and can load up the Mediawiki server for large wikis.
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ To start an export, you will need the URL of the mediawiki API (usually http://m
 
 If you need to log in to to your Mediawiki install (either with a Mediawiki username and if you are in a domain with the domain-name, or via HTTP Basic Auth) then run `yamdwe.py -h` to view the command line options for authentication.
 
+Domain functionality is added through the "develop" branch of this [simplemediawiki fork](https://github.com/BlackLotus/python-simplemediawiki/tree/develop) and can be used through.
+
+    yamdwe.py --wiki_domain WIKI_DOMAIN MEDIAWIKI_API_URL DOKUWIKI_ROOT_PATH
+
 If installation goes well it should print the names of pages and images as it is exporting, and finally print "Done". This process can be slow, and can load up the Mediawiki server for large wikis.
 
 Yamdwe may warn you at the end that it is unable to set [correct permissions for the Dokuwiki data directories and files](https://www.dokuwiki.org/install:permissions) - regardless, you should check and correct these manually.

--- a/mediawiki.py
+++ b/mediawiki.py
@@ -11,9 +11,12 @@ import re
 from pprint import pprint
 
 class Importer(object):
-    def __init__(self, api_url, http_user=None, http_pass="", wiki_user=None, wiki_pass="", wiki_domain="", verbose=False):
+    def __init__(self, api_url, http_user=None, http_pass="", wiki_user=None, wiki_pass="", wiki_domain=None, verbose=False):
         self.verbose = verbose
-        self.mw = simplemediawiki.MediaWiki(api_url, http_user=http_user, http_password=http_pass, domain=wiki_domain)
+        if wiki_domain:
+            self.mw = simplemediawiki.MediaWiki(api_url, http_user=http_user, http_password=http_pass, domain=wiki_domain)
+        else:
+            self.mw = simplemediawiki.MediaWiki(api_url, http_user=http_user, http_password=http_pass)
         # login if necessary
         if wiki_user is not None:
             print("Logging in as %s..." % wiki_user)

--- a/mediawiki.py
+++ b/mediawiki.py
@@ -11,9 +11,9 @@ import re
 from pprint import pprint
 
 class Importer(object):
-    def __init__(self, api_url, http_user=None, http_pass="", wiki_user=None, wiki_pass="", verbose=False):
+    def __init__(self, api_url, http_user=None, http_pass="", wiki_user=None, wiki_pass="", wiki_domain="", verbose=False):
         self.verbose = verbose
-        self.mw = simplemediawiki.MediaWiki(api_url,http_user=http_user,http_password=http_pass)
+        self.mw = simplemediawiki.MediaWiki(api_url, http_user=http_user, http_password=http_pass, domain=wiki_domain)
         # login if necessary
         if wiki_user is not None:
             print("Logging in as %s..." % wiki_user)

--- a/mediawiki.py
+++ b/mediawiki.py
@@ -34,30 +34,14 @@ class Importer(object):
         if self.verbose:
             print(msg)
 
-    def get_all_pages(self, limit=500, more=True):
-        # the mediawiki api right now limits the pulled pages to 10
-        # the maximum allowed is 500
-        # after the first pages are pulled there is no check if there are additional pages to load
-        # if more is set one additional pull is done that resumes at the last pulled entry
-        # and it stops if the last page is the last page ;)
+    def get_all_pages(self):
         """
         Slurp all pages down from the mediawiki instance, together with all revisions including content.
         WARNING: Hits API hard, don't do this without knowledge/permission of wiki operator!!
         """
-        count=1
-        newest=0
-        query = {'list' : 'allpages', 'aplimit':limit}
-        print("Getting list of pages 0-%i..." % limit)
+        query = {'list' : 'allpages'}
+        print("Getting list of pages...")
         pages = self._query(query, [ 'allpages' ])
-
-        while newest != pages[-1]['pageid'] and more:
-            print("Getting list of pages %i-%i..." % (count * limit, (count + 1) * limit))
-            newest = pages[-1]['pageid']
-            query = {'list': 'allpages', 'aplimit': 500, 'apfrom': pages[-1]['title']}
-            pages += self._query(query, ['allpages'])
-#            print("Newest is %s and the ''newest'' is %s" % (newest, pages[-1]['pageid']))
-            count += 1
-
         self.verbose_print("Got %d pages." % len(pages))
         print("Query page revisions (this may take a while)...")
         for page in pages:

--- a/yamdwe.py
+++ b/yamdwe.py
@@ -15,6 +15,7 @@ from __future__ import print_function, unicode_literals, absolute_import, divisi
 import argparse, sys, codecs, locale, getpass, datetime
 from pprint import pprint
 import mediawiki, dokuwiki, wikicontent
+import inspect
 
 def main():
     # the wikicontent code (that uses visitor module) tends to recurse quite deeply for complex pages
@@ -38,7 +39,10 @@ def main():
     if not args.mediawiki.endswith("api.php"):
         print("WARNING: Mediawiki URL does not end in 'api.php'... This has to be the URL of the Mediawiki API, not just the wiki. If you can't export anything, try adding '/api.php' to the wiki URL.")
 
-    importer = mediawiki.Importer(args.mediawiki, args.http_user, args.http_pass, args.wiki_user, args.wiki_pass, args.wiki_domain, args.verbose)
+    if "domain" in inspect.getargspec(simplemediawiki.MediaWiki.__init__)[0]:
+        importer = mediawiki.Importer(args.mediawiki, args.http_user, args.http_pass, args.wiki_user, args.wiki_pass, args.wiki_domain, args.verbose)
+    else:
+        importer = mediawiki.Importer(args.mediawiki, args.http_user, args.http_pass, args.wiki_user, args.wiki_pass, args.verbose)
     exporter = dokuwiki.Exporter(args.dokuwiki)
 
     # Set the wikicontent's definition of File: and Image: prefixes (varies by language settings)
@@ -85,7 +89,8 @@ arguments.add_argument('--http_user', help="Username for HTTP basic auth")
 arguments.add_argument('--http_pass', help="Password for HTTP basic auth (if --http_user is specified but not --http_pass, yamdwe will prompt for a password)")
 arguments.add_argument('--wiki_user', help="Mediawiki login username")
 arguments.add_argument('--wiki_pass', help="Mediawiki login password (if --wiki_user is specified but not --wiki_pass, yamdwe will prompt for a password)")
-arguments.add_argument('--wiki_domain', help="Mediawiki login domain (needs a non-standard simplemediawiki library)")
+if "domain" in inspect.getargspec(simplemediawiki.MediaWiki.__init__)[0]:
+    arguments.add_argument('--wiki_domain', help="Mediawiki login domain (needs a non-standard simplemediawiki library)")
 arguments.add_argument('-v', '--verbose',help="Print verbose progress and error messages", action="store_true")
 arguments.add_argument('mediawiki', metavar='MEDIAWIKI_API_URL', help="URL of mediawiki's api.php file (something like http://mysite/wiki/api.php)")
 arguments.add_argument('dokuwiki', metavar='DOKUWIKI_ROOT', help="Root path to an existing dokuwiki installation to add the Mediawiki pages to (can be a brand new install.)")

--- a/yamdwe.py
+++ b/yamdwe.py
@@ -51,6 +51,7 @@ def main():
 
     # Add a shameless "exported by yamdwe" note to the front page of the wiki - really shameless, but I'll keep it
     mainpage = importer.get_main_pagetitle()
+
     for page in pages:
         if page["title"] == mainpage:
             latest = dict(page["revisions"][0])
@@ -84,7 +85,7 @@ arguments.add_argument('--http_user', help="Username for HTTP basic auth")
 arguments.add_argument('--http_pass', help="Password for HTTP basic auth (if --http_user is specified but not --http_pass, yamdwe will prompt for a password)")
 arguments.add_argument('--wiki_user', help="Mediawiki login username")
 arguments.add_argument('--wiki_pass', help="Mediawiki login password (if --wiki_user is specified but not --wiki_pass, yamdwe will prompt for a password)")
-arguments.add_argument('--wiki_domain', help="Mediawiki login domain")
+arguments.add_argument('--wiki_domain', help="Mediawiki login domain (needs a non-standard simplemediawiki library )")
 arguments.add_argument('-v', '--verbose',help="Print verbose progress and error messages", action="store_true")
 arguments.add_argument('mediawiki', metavar='MEDIAWIKI_API_URL', help="URL of mediawiki's api.php file (something like http://mysite/wiki/api.php)")
 arguments.add_argument('dokuwiki', metavar='DOKUWIKI_ROOT', help="Root path to an existing dokuwiki installation to add the Mediawiki pages to (can be a brand new install.)")

--- a/yamdwe.py
+++ b/yamdwe.py
@@ -38,7 +38,7 @@ def main():
     if not args.mediawiki.endswith("api.php"):
         print("WARNING: Mediawiki URL does not end in 'api.php'... This has to be the URL of the Mediawiki API, not just the wiki. If you can't export anything, try adding '/api.php' to the wiki URL.")
 
-    importer = mediawiki.Importer(args.mediawiki, args.http_user, args.http_pass, args.wiki_user, args.wiki_pass, args.verbose)
+    importer = mediawiki.Importer(args.mediawiki, args.http_user, args.http_pass, args.wiki_user, args.wiki_pass, args.wiki_domain, args.verbose)
     exporter = dokuwiki.Exporter(args.dokuwiki)
 
     # Set the wikicontent's definition of File: and Image: prefixes (varies by language settings)
@@ -49,7 +49,7 @@ def main():
     pages = importer.get_all_pages()
     print("Found %d pages to export..." % len(pages))
 
-    # Add a shameless "exported by yamdwe" note to the front page of the wiki
+    # Add a shameless "exported by yamdwe" note to the front page of the wiki - really shameless, but I'll keep it
     mainpage = importer.get_main_pagetitle()
     for page in pages:
         if page["title"] == mainpage:
@@ -84,6 +84,7 @@ arguments.add_argument('--http_user', help="Username for HTTP basic auth")
 arguments.add_argument('--http_pass', help="Password for HTTP basic auth (if --http_user is specified but not --http_pass, yamdwe will prompt for a password)")
 arguments.add_argument('--wiki_user', help="Mediawiki login username")
 arguments.add_argument('--wiki_pass', help="Mediawiki login password (if --wiki_user is specified but not --wiki_pass, yamdwe will prompt for a password)")
+arguments.add_argument('--wiki_domain', help="Mediawiki login domain")
 arguments.add_argument('-v', '--verbose',help="Print verbose progress and error messages", action="store_true")
 arguments.add_argument('mediawiki', metavar='MEDIAWIKI_API_URL', help="URL of mediawiki's api.php file (something like http://mysite/wiki/api.php)")
 arguments.add_argument('dokuwiki', metavar='DOKUWIKI_ROOT', help="Root path to an existing dokuwiki installation to add the Mediawiki pages to (can be a brand new install.)")

--- a/yamdwe.py
+++ b/yamdwe.py
@@ -15,7 +15,8 @@ from __future__ import print_function, unicode_literals, absolute_import, divisi
 import argparse, sys, codecs, locale, getpass, datetime
 from pprint import pprint
 import mediawiki, dokuwiki, wikicontent
-import inspect
+# only needed to check for domain functionality
+import simplemediawiki, inspect
 
 def main():
     # the wikicontent code (that uses visitor module) tends to recurse quite deeply for complex pages

--- a/yamdwe.py
+++ b/yamdwe.py
@@ -49,7 +49,7 @@ def main():
     pages = importer.get_all_pages()
     print("Found %d pages to export..." % len(pages))
 
-    # Add a shameless "exported by yamdwe" note to the front page of the wiki - really shameless, but I'll keep it
+    # Add a shameless "exported by yamdwe" note to the front page of the wiki
     mainpage = importer.get_main_pagetitle()
 
     for page in pages:
@@ -85,7 +85,7 @@ arguments.add_argument('--http_user', help="Username for HTTP basic auth")
 arguments.add_argument('--http_pass', help="Password for HTTP basic auth (if --http_user is specified but not --http_pass, yamdwe will prompt for a password)")
 arguments.add_argument('--wiki_user', help="Mediawiki login username")
 arguments.add_argument('--wiki_pass', help="Mediawiki login password (if --wiki_user is specified but not --wiki_pass, yamdwe will prompt for a password)")
-arguments.add_argument('--wiki_domain', help="Mediawiki login domain (needs a non-standard simplemediawiki library )")
+arguments.add_argument('--wiki_domain', help="Mediawiki login domain (needs a non-standard simplemediawiki library)")
 arguments.add_argument('-v', '--verbose',help="Print verbose progress and error messages", action="store_true")
 arguments.add_argument('mediawiki', metavar='MEDIAWIKI_API_URL', help="URL of mediawiki's api.php file (something like http://mysite/wiki/api.php)")
 arguments.add_argument('dokuwiki', metavar='DOKUWIKI_ROOT', help="Root path to an existing dokuwiki installation to add the Mediawiki pages to (can be a brand new install.)")


### PR DESCRIPTION
You sometimes have to login through a domain. The domain functionality isn't provided by the default [simplemediawiki](https://github.com/ianweller/python-simplemediawiki), but there are [forks](https://github.com/BlackLotus/python-simplemediawiki) and [pull requests](https://github.com/ianweller/python-simplemediawiki/pull/21) to add this (simple) functionality. This pull requests doesn't have checks if the domain functionality exists, but adds the option and a note.
A pull from one of the other sources or your own fork + an udate of the README should be sufficient.
Oh and the api doesn't allow pulls of the whole wiki right now and limits it to 10 entries [by default](https://www.mediawiki.org/wiki/API:Allpages) and can be set to a max of [500](https://www.mediawiki.org/wiki/API:Lists) which this patch also fixes (I can split it if necessary).