### PR TITLE
Page pull limit fix

### DIFF
--- a/mediawiki.py
+++ b/mediawiki.py
@@ -11,9 +11,9 @@ import re
 from pprint import pprint
 
 class Importer(object):
-    def __init__(self, api_url, http_user=None, http_pass="", wiki_user=None, wiki_pass="", wiki_domain="", verbose=False):
+    def __init__(self, api_url, http_user=None, http_pass="", wiki_user=None, wiki_pass="", verbose=False):
         self.verbose = verbose
-        self.mw = simplemediawiki.MediaWiki(api_url, http_user=http_user, http_password=http_pass, domain=wiki_domain)
+        self.mw = simplemediawiki.MediaWiki(api_url,http_user=http_user,http_password=http_pass)
         # login if necessary
         if wiki_user is not None:
             print("Logging in as %s..." % wiki_user)

--- a/mediawiki.py
+++ b/mediawiki.py
@@ -11,9 +11,9 @@ import re
 from pprint import pprint
 
 class Importer(object):
-    def __init__(self, api_url, http_user=None, http_pass="", wiki_user=None, wiki_pass="", verbose=False):
+    def __init__(self, api_url, http_user=None, http_pass="", wiki_user=None, wiki_pass="", wiki_domain="", verbose=False):
         self.verbose = verbose
-        self.mw = simplemediawiki.MediaWiki(api_url,http_user=http_user,http_password=http_pass)
+        self.mw = simplemediawiki.MediaWiki(api_url, http_user=http_user, http_password=http_pass, domain=wiki_domain)
         # login if necessary
         if wiki_user is not None:
             print("Logging in as %s..." % wiki_user)

--- a/yamdwe.py
+++ b/yamdwe.py
@@ -38,7 +38,7 @@ def main():
     if not args.mediawiki.endswith("api.php"):
         print("WARNING: Mediawiki URL does not end in 'api.php'... This has to be the URL of the Mediawiki API, not just the wiki. If you can't export anything, try adding '/api.php' to the wiki URL.")
 
-    importer = mediawiki.Importer(args.mediawiki, args.http_user, args.http_pass, args.wiki_user, args.wiki_pass, args.wiki_domain, args.verbose)
+    importer = mediawiki.Importer(args.mediawiki, args.http_user, args.http_pass, args.wiki_user, args.wiki_pass, args.verbose)
     exporter = dokuwiki.Exporter(args.dokuwiki)
 
     # Set the wikicontent's definition of File: and Image: prefixes (varies by language settings)
@@ -49,7 +49,7 @@ def main():
     pages = importer.get_all_pages()
     print("Found %d pages to export..." % len(pages))
 
-    # Add a shameless "exported by yamdwe" note to the front page of the wiki - really shameless, but I'll keep it
+    # Add a shameless "exported by yamdwe" note to the front page of the wiki
     mainpage = importer.get_main_pagetitle()
     for page in pages:
         if page["title"] == mainpage:
@@ -84,7 +84,6 @@ arguments.add_argument('--http_user', help="Username for HTTP basic auth")
 arguments.add_argument('--http_pass', help="Password for HTTP basic auth (if --http_user is specified but not --http_pass, yamdwe will prompt for a password)")
 arguments.add_argument('--wiki_user', help="Mediawiki login username")
 arguments.add_argument('--wiki_pass', help="Mediawiki login password (if --wiki_user is specified but not --wiki_pass, yamdwe will prompt for a password)")
-arguments.add_argument('--wiki_domain', help="Mediawiki login domain")
 arguments.add_argument('-v', '--verbose',help="Print verbose progress and error messages", action="store_true")
 arguments.add_argument('mediawiki', metavar='MEDIAWIKI_API_URL', help="URL of mediawiki's api.php file (something like http://mysite/wiki/api.php)")
 arguments.add_argument('dokuwiki', metavar='DOKUWIKI_ROOT', help="Root path to an existing dokuwiki installation to add the Mediawiki pages to (can be a brand new install.)")

--- a/yamdwe.py
+++ b/yamdwe.py
@@ -38,7 +38,7 @@ def main():
     if not args.mediawiki.endswith("api.php"):
         print("WARNING: Mediawiki URL does not end in 'api.php'... This has to be the URL of the Mediawiki API, not just the wiki. If you can't export anything, try adding '/api.php' to the wiki URL.")
 
-    importer = mediawiki.Importer(args.mediawiki, args.http_user, args.http_pass, args.wiki_user, args.wiki_pass, args.verbose)
+    importer = mediawiki.Importer(args.mediawiki, args.http_user, args.http_pass, args.wiki_user, args.wiki_pass, args.wiki_domain, args.verbose)
     exporter = dokuwiki.Exporter(args.dokuwiki)
 
     # Set the wikicontent's definition of File: and Image: prefixes (varies by language settings)
@@ -49,7 +49,7 @@ def main():
     pages = importer.get_all_pages()
     print("Found %d pages to export..." % len(pages))
 
-    # Add a shameless "exported by yamdwe" note to the front page of the wiki
+    # Add a shameless "exported by yamdwe" note to the front page of the wiki - really shameless, but I'll keep it
     mainpage = importer.get_main_pagetitle()
     for page in pages:
         if page["title"] == mainpage:
@@ -84,6 +84,7 @@ arguments.add_argument('--http_user', help="Username for HTTP basic auth")
 arguments.add_argument('--http_pass', help="Password for HTTP basic auth (if --http_user is specified but not --http_pass, yamdwe will prompt for a password)")
 arguments.add_argument('--wiki_user', help="Mediawiki login username")
 arguments.add_argument('--wiki_pass', help="Mediawiki login password (if --wiki_user is specified but not --wiki_pass, yamdwe will prompt for a password)")
+arguments.add_argument('--wiki_domain', help="Mediawiki login domain")
 arguments.add_argument('-v', '--verbose',help="Print verbose progress and error messages", action="store_true")
 arguments.add_argument('mediawiki', metavar='MEDIAWIKI_API_URL', help="URL of mediawiki's api.php file (something like http://mysite/wiki/api.php)")
 arguments.add_argument('dokuwiki', metavar='DOKUWIKI_ROOT', help="Root path to an existing dokuwiki installation to add the Mediawiki pages to (can be a brand new install.)")


### PR DESCRIPTION
The api doesn't allow pulls of the whole wiki right now and limits it to 10 entries [by default](https://www.mediawiki.org/wiki/API:Allpages) and can be set to a max of [500](https://www.mediawiki.org/wiki/API:Lists) which this patch fixes.