### PR TITLE
new sections test case for failing heading

### DIFF
--- a/tests/header_anchors/dokuwiki.txt
+++ b/tests/header_anchors/dokuwiki.txt
@@ -1,39 +1,39 @@
-==== Section A ====
+====== Section A ======
 
 
 this section has a plaintext anchor link. [[#Section_C]]
 
 
-==== Section B ====
+====== Section B ======
 
 
 this section has an anchor link formatted as Mediawiki formats them. [[#Section_A]]
 
 
-==== Section C ====
+====== Section C ======
 
 
 this section has a page link with a plaintext anchor component [[page#Section_C]]
 
 
-==== Section D & complex Noteworthiness ====
+====== Section D & complex Noteworthiness ======
 
 
 this section has a page link with a complex anchor component [[#Section_D_complex_Noteworthiness]]
 
 
-=== Bork bork ===
+===== Bork bork =====
 
 
 this subsection has a page link with a mediawiki-formatted anchor component. [[page#Section_C]]
 
 
-=== SectionHeaderWithUppercaseLetters E ===
+===== SectionHeaderWithUppercaseLetters E =====
 
 [[#SectionHeaderWithUppercaseLetters_E]]
 
 
-=== Section header with - minus ===
+===== Section header with - minus =====
 
 [[#Section_header_with_-_minus]]
 

--- a/tests/notoc/dokuwiki.txt
+++ b/tests/notoc/dokuwiki.txt
@@ -1,5 +1,5 @@
 ~~NOTOC~~
 
-====== Heading ======
+======= Heading =======
 
 Based on issue seen in https://github.com/projectgus/yamdwe/issues/30

--- a/tests/notoc/dokuwiki.txt
+++ b/tests/notoc/dokuwiki.txt
@@ -1,5 +1,5 @@
 ~~NOTOC~~
 
-===== Heading =====
+====== Heading ======
 
 Based on issue seen in https://github.com/projectgus/yamdwe/issues/30

--- a/tests/sections_test/dokuwiki.txt
+++ b/tests/sections_test/dokuwiki.txt
@@ -1,16 +1,13 @@
-====== Heading ======
+====== Section ======
 
 
-===== Section =====
+===== Subsection =====
 
 
-==== Subsection ====
+==== Sub-subsection ====
 
 
-=== Sub-subsection ===
-
-
-== Sub-Sub-subsection ==
+=== Sub-Sub-subsection ===
 
 
 == Sub-Sub-Sub-subsection ==

--- a/tests/sections_test/dokuwiki.txt
+++ b/tests/sections_test/dokuwiki.txt
@@ -1,0 +1,16 @@
+====== Heading ======
+
+
+===== Section =====
+
+
+==== Subsection ====
+
+
+=== Sub-subsection ===
+
+
+== Sub-Sub-subsection ==
+
+
+== Sub-Sub-Sub-subsection ==

--- a/tests/sections_test/mediawiki.txt
+++ b/tests/sections_test/mediawiki.txt
@@ -1,4 +1,3 @@
-= Heading =
 == Section ==
 === Subsection ===
 ==== Sub-subsection ====

--- a/tests/sections_test/mediawiki.txt
+++ b/tests/sections_test/mediawiki.txt
@@ -1,0 +1,6 @@
+= Heading =
+== Section ==
+=== Subsection ===
+==== Sub-subsection ====
+===== Sub-Sub-subsection =====
+====== Sub-Sub-Sub-subsection ======


### PR DESCRIPTION
As seen under https://www.mediawiki.org/wiki/Help:Formatting#Text_formatting_markup there are Sections from == to ======
(= is a heading and is harder to handle so I left it out here, if it would be included it wouldn't work for ===== and ======).

Right now yamdwe converts ===== to = which doesn't even exist and converts ====== to "" (nothing).
I will probably add a fix later as well.