### PR TITLE
fixed the level heading/section conversion from 6 to 8

### DIFF
--- a/wikicontent.py
+++ b/wikicontent.py
@@ -112,7 +112,7 @@ def convert(section, context, trailing_newline):
     elif section.tagname == "@section":
         level = section.level
         heading = convert(section.children.pop(0), context, trailing_newline).strip()
-        heading_boundary = "="*(6-level)
+        heading_boundary = "="*(8-level)
         result = "\n%s %s %s\n" % (heading_boundary, heading, heading_boundary)
     else:
         print("Unknown tagname %s" % section.tagname)


### PR DESCRIPTION
Like I said in pull request #41 the conversion of sections/headings is wrong.
This simple fix should work thought.
I created an additional pull request for it, if requested I can add this fix to the test case pull request as well.