### PR TITLE
throw basic warnings whenever they occur

### DIFF
--- a/mediawiki.py
+++ b/mediawiki.py
@@ -108,7 +108,7 @@ class Importer(object):
             # if there's a warning print it out (shouldn't need a debug flag since this is of interest to any user)
             if 'warnings' in response:
                 for warnkey in response['warnings']:
-                    print("WARNING: %s function throws the warning %s" % warnkey, response['warnings'][warnkey]['*']))
+                    print("WARNING: %s function throws the warning %s" % (warnkey, response['warnings'][warnkey]['*']))
 
             # if there's a continuation, find the new arguments and follow them
             try:

--- a/mediawiki.py
+++ b/mediawiki.py
@@ -105,6 +105,11 @@ class Importer(object):
                 raise RuntimeError("Mediawiki query '%s' returned unexpected response '%s' after %d continuations" % (args, response, continuations))
             result += inner
 
+            # if there's a warning print it out (shouldn't need a debug flag since this is of interest to any user)
+            if 'warnings' in response:
+                for warnkey in response['warnings']:
+                    print("WARNING: %s function throws the warning %s" % warnkey, response['warnings'][warnkey]['*']))
+
             # if there's a continuation, find the new arguments and follow them
             try:
                 query.update(response['query-continue'][path_to_result[-1]])


### PR DESCRIPTION
This would have shown me the problem that caused #40. This is only warning handling and no error handling. 
See https://www.mediawiki.org/wiki/API:Errors_and_warnings for information, about the warnings functions of the mediawiki API.