### PR TITLE
Support rawcontinue for mediawiki version >=1.24

### DIFF
--- a/mediawiki.py
+++ b/mediawiki.py
@@ -22,6 +22,7 @@ class Importer(object):
 
         # version check
         try:
+            self.need_rawcontinue = False
             generator = "".join(self._query({'meta' : 'siteinfo'}, ['general', 'generator']))
             version = [ int(x) for x in re.search(r'[0-9.]+', generator).group(0).split(".") ] # list of [ 1, 19, 1 ] or similar
             if version[0] == 1 and version[1] < 13:


### PR DESCRIPTION
Required on 1.26 or newer for successful query.

Based on #43, but adds a version check.