### PR TITLE
Convert page names and links to lowercase.

### DIFF
--- a/dokuwiki.py
+++ b/dokuwiki.py
@@ -194,7 +194,11 @@ def make_dokuwiki_pagename(mediawiki_name):
     result = mediawiki_name.replace(" ","_")
     # We have pages that have ':' in them - replace with underscores
     result = result.replace(':', '_')
-    result = names.clean_id(camel_to_underscore(result)).replace("/",":")
+    # Inconsistent use to camel case and/or all lower means allowing
+    # converstion to camelcase breaks our wiki.
+    #result = names.clean_id(camel_to_underscore(result)).replace("/",":")
+    # Just convert everything to lowercase instead.  It's safer.
+    result = names.clean_id(result.lower()).replace("/",":")
     # Some of our mediawiki page names begin with a '/', which results in os.path.join assuming the page is an absolute path.
     if result[0] == ':':
       result = result.lstrip(':')


### PR DESCRIPTION
This is instead of converting cAmElcase to c_am_elcase as the insertion of
underscores breaks links if there is *any* inconsistency between
case used in pagenames and links (but mediawiki lets you get away with
it).